### PR TITLE
Add systemd support

### DIFF
--- a/tasks/teamcity-agent.yml
+++ b/tasks/teamcity-agent.yml
@@ -38,11 +38,19 @@
     dest: "/etc/default/teamcity-agent"
     mode: 0644
 
-- name: "Put TeamCity Agent service file"
+- name: "Put TeamCity Agent service file (sysv)"
   template:
     src: "teamcity-agent.conf.j2"
     dest: "/etc/init/teamcity-agent.conf"
     mode: 0644
+  when: "ansible_service_mgr != 'systemd'"
+
+- name: "Put TeamCity Agent service file (systemd)"
+  template:
+    src: "teamcity-agent.service.j2"
+    dest: "/lib/systemd/system/teamcity-agent.service"
+    #mode: 0644
+  when: "ansible_service_mgr == 'systemd'"
 
 - name: "Save agent auth token"
   shell: "grep authorizationToken {{ teamcity_agent_install_dir }}/conf/buildAgent.properties | sed 's/authorizationToken=//g'"

--- a/templates/teamcity-agent.service.j2
+++ b/templates/teamcity-agent.service.j2
@@ -1,0 +1,10 @@
+#/lib/systemd/system
+[Unit]
+Description="TeamCity Agent"
+
+[Service]
+User={{ teamcity_server_user_name }}
+ExecStart={{ teamcity_agent_install_dir }}/bin/agent.sh run
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
When the service manager is systemd, use the teamcity-agent.service.j2
systemd unit file to install the service instead of the sysv init
script.