### PR TITLE
Fix teamcity_agent_hostname to actually use the hostname

### DIFF
--- a/templates/teamcity-agent.service.j2
+++ b/templates/teamcity-agent.service.j2
@@ -3,7 +3,7 @@
 Description="TeamCity Agent"
 
 [Service]
-User={{ teamcity_server_user }}
+User={{ teamcity_agent_user }}
 ExecStartPre=". /etc/default/teamcity-agent"
 ExecStart={{ teamcity_agent_install_dir }}/bin/agent.sh run
 ExecStop={{ teamcity_agent_install_dir }}/bin/agent.sh stop

--- a/templates/teamcity-agent.service.j2
+++ b/templates/teamcity-agent.service.j2
@@ -3,7 +3,7 @@
 Description="TeamCity Agent"
 
 [Service]
-User={{ teamcity_server_user_name }}
+User={{ teamcity_server_user }}
 ExecStartPre=". /etc/default/teamcity-agent"
 ExecStart={{ teamcity_agent_install_dir }}/bin/agent.sh run
 ExecStop={{ teamcity_agent_install_dir }}/bin/agent.sh stop

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 teamcity_agent_user: teamcity
 teamcity_agent_group: teamcity
 teamcity_agent_home: /home/teamcity
-teamcity_agent_hostname: "{{ inventory_hostname_short }}"
+teamcity_agent_hostname: "{{ ansible_hostname }}"
 
 teamcity_server_user_name: teamcity
 teamcity_server_user_passwd: teamcity

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 teamcity_agent_user: teamcity
 teamcity_agent_group: teamcity
 teamcity_agent_home: /home/teamcity
-teamcity_agent_hostname: "{{ ansible_inventory_hostname_short }}"
+teamcity_agent_hostname: "{{ inventory_hostname_short }}"
 
 teamcity_server_user_name: teamcity
 teamcity_server_user_passwd: teamcity

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 teamcity_agent_user: teamcity
 teamcity_agent_group: teamcity
 teamcity_agent_home: /home/teamcity
-teamcity_agent_hostname: "{{ ansible_eth0['ipv4']['address'] }}"
+teamcity_agent_hostname: "{{ ansible_inventory_hostname_short }}"
 
 teamcity_server_user_name: teamcity
 teamcity_server_user_passwd: teamcity

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,3 @@ teamcity_agent_user: teamcity
 teamcity_agent_group: teamcity
 teamcity_agent_home: /home/teamcity
 teamcity_agent_hostname: "{{ ansible_hostname }}"
-
-teamcity_server_user_name: teamcity
-teamcity_server_user_passwd: teamcity


### PR DESCRIPTION
Hi,

I replaced the use of the default eth0 interface's address with the ansible provided variable `inventory_hostname_short`, which will use the short name (up to the first .) from the ansible inventory.
I encountered a problem using Ubuntu 16.04, where you usually don't have a `eth0` interface.

Also, I find it makes more sense to actually use the hostname as a name for the build agent.

Thanks for putting together this role! :-)