### PR TITLE
Misleading role vars

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 teamcity_agent_user: teamcity
 teamcity_agent_group: teamcity
 teamcity_agent_home: /home/teamcity
-teamcity_agent_hostname: "{{ inventory_hostname_short }}"
+teamcity_agent_hostname: "{{ ansible_hostname }}"
 
 teamcity_server_user_name: teamcity
 teamcity_server_user_passwd: teamcity

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 teamcity_agent_user: teamcity
 teamcity_agent_group: teamcity
 teamcity_agent_home: /home/teamcity
-teamcity_agent_hostname: "{{ ansible_inventory_hostname_short }}"
+teamcity_agent_hostname: "{{ inventory_hostname_short }}"
 
 teamcity_server_user_name: teamcity
 teamcity_server_user_passwd: teamcity

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 teamcity_agent_user: teamcity
 teamcity_agent_group: teamcity
 teamcity_agent_home: /home/teamcity
-teamcity_agent_hostname: "{{ ansible_eth0['ipv4']['address'] }}"
+teamcity_agent_hostname: "{{ ansible_inventory_hostname_short }}"
 
 teamcity_server_user_name: teamcity
 teamcity_server_user_passwd: teamcity


### PR DESCRIPTION
In addition to `defaults/main.yml` the variables `teamcity_server_user_name` and `teamcity_server_user_passwd` were also defined in `vars/main.yml`.
Therefore you could not override them in an inventory, which was misleading since they were also put in `defaults/main.yml`, which CAN be overridden by inventory group vars.

I removed the duplicates in `vars/main.yml`.